### PR TITLE
Fix rendering request message

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -22,25 +22,40 @@ RSpec.configure do |config|
       file_name = $1.underscore
 
       File.open(File.join(Rails.root, "/docs/#{file_name}.txt"), 'a') do |f|
-        f.write "# #{action} \n\n"
 
+        # Resource & Action
+        f.write "# #{action}\n\n"
+
+        # Request
         request_body = request.body.read
+        if request_body.present? or request.headers['Authorization']
+          f.write "+ Request (application/json)\n\n"
+  
+          authorizationHeader = request.headers['Authorization']
 
-        if request.headers['Authorization']
-          f.write "+ Request Headers \n\n"
-          f.write "Authorization: #{request.headers['Authorization']} \n\n".indent(4)
+          # Request Headers
+          if authorizationHeader
+            f.write "+ Headers\n\n".indent(4)
+            f.write "Authorization: #{authorizationHeader}\n\n".indent(12)
+          end
+
+          # Request Body
+          if request_body.present?
+            if authorizationHeader
+              f.write "+ Body\n\n".indent(4)
+            end
+
+            f.write "#{JSON.pretty_generate(JSON.parse(request_body))}\n\n".indent(authorizationHeader ? 12 : 8)
+          end
+
         end
 
-        if request_body.present?
-          f.write "+ Request (application/json) \n\n"
-          f.write "#{JSON.pretty_generate(JSON.parse(request_body))} \n\n".indent(4)
-        end
-
-        f.write "+ Response #{response.status} (application/json) \n\n"
-
+        # Response
+        f.write "+ Response #{response.status} (application/json)\n\n"
         if response.body.present?
-          f.write "#{JSON.pretty_generate(JSON.parse(response.body))} \n\n".indent(4)
+          f.write "#{JSON.pretty_generate(JSON.parse(response.body))}\n\n".indent(8)
         end
+
       end unless response.status == 401 || response.status == 403 || response.status == 301
     end
   end


### PR DESCRIPTION
Given the example on [this blog post](http://matteodepalo.github.io/blog/2013/07/24/rails-api-documentation/). The correct API Blueprint rendered would be:

``` markdown
# POST /v1/rounds

+ Request (application/json)

    + Headers

            Authorization: Token token="36260243e091bfe56f96483592afc723"

    + Body

            {
              "round": {
                "game_name": "dota2",
                "arena": {
                  "foursquare_id": "5104"
                }
              }
            }

+ Response 201 (application/json)

        {
          "round": {
            "id": "ec6add8b-709f-475d-8f06-8ad44d8a95d3",
            "state": "waiting_for_players",
            "created_at": "2013-07-24T12:16:14.700Z",
            "game": {
              "id": "1c59b30e-599a-4ea1-9d5c-a364079528ad",
              "name": "dota2",
              "display_name": "Dota 2",
              "picture_url": "http://localhost:8080/assets/dota2.jpg",
              "teams": [
                {
                  "name": "radiant",
                  "display_name": "Radiant",
                  "number_of_players": 5
                },
                {
                  "name": "dire",
                  "display_name": "Dire",
                  "number_of_players": 5
                }
              ]
            },
            "arena": {
              "id": "5c593125-a114-4a1a-936f-2cc4b21fa0a8",
              "name": "Clinton St. Baking Co. & Restaurant",
              "latitude": 40.721294,
              "longitude": -73.983994,
              "foursquare_id": "5104"
            },
            "teams": [

            ],
            "user": {
              "id": "87fb0fe4-2f0c-400d-ba00-000c3f5ea642",
              "name": "Test User",
              "picture_url": "http://graph.facebook.com/12132/picture?type=square",
              "facebook_id": "12132"
            }
          }
        }

```
