### PR TITLE
Non-rails project workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ The output:
           }
         }
 
+### Non-rails apps
+
+If you aren't using Rails, add this line to your RSpec config block
+
+    config.add_setting :current_dir, :default => File.dirname(__FILE__)+'/..'
+
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,6 @@ The output:
           }
         }
 
-### Non-rails apps
-
-If you aren't using Rails, add this line to your RSpec config block
-
-    config.add_setting :current_dir, :default => File.dirname(__FILE__)+'/..'
-
-
 ## Caveats
 
 401, 403 and 301 statuses are ignored since rspec produces a undesired output.

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -1,13 +1,15 @@
 require "rspec_api_blueprint/version"
 require "rspec_api_blueprint/string_extensions"
 
+
 RSpec.configure do |config|
   config.before(:suite) do
     if defined? Rails
       api_docs_folder_path = File.join(Rails.root, '/api_docs/')
-    else # slight hackery based on a custom setting defined in the RSpec config
-      api_docs_folder_path = File.join(config.current_dir, '/api_docs/')
+    else
+      api_docs_folder_path = File.join(File.expand_path('.'), '/api_docs/')
     end
+
     Dir.mkdir(api_docs_folder_path) unless Dir.exists?(api_docs_folder_path)
 
     Dir.glob(File.join(api_docs_folder_path, '*')).each do |f|
@@ -31,8 +33,8 @@ RSpec.configure do |config|
 
       if defined? Rails
         file = File.join(Rails.root, "/api_docs/#{file_name}.txt")
-      else # slight hackery based on a custom setting defined in the RSpec config
-        file = File.join(config.current_dir, "/api_docs/#{file_name}.txt")
+      else 
+        file = File.join(File.expand_path('.'), "/api_docs/#{file_name}.txt")
       end
 
       File.open(file, 'a') do |f|

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -3,7 +3,11 @@ require "rspec_api_blueprint/string_extensions"
 
 RSpec.configure do |config|
   config.before(:suite) do
-    api_docs_folder_path = File.join(Rails.root, '/api_docs/')
+    if defined? Rails
+      api_docs_folder_path = File.join(Rails.root, '/api_docs/')
+    else # slight hackery based on a custom setting defined in the RSpec config
+      api_docs_folder_path = File.join(config.current_dir, '/api_docs/')
+    end
     Dir.mkdir(api_docs_folder_path) unless Dir.exists?(api_docs_folder_path)
 
     Dir.glob(File.join(api_docs_folder_path, '*')).each do |f|
@@ -25,7 +29,13 @@ RSpec.configure do |config|
       example_groups[-1][:description_args].first.match(/(\w+)\sRequests/)
       file_name = $1.underscore
 
-      File.open(File.join(Rails.root, "/api_docs/#{file_name}.txt"), 'a') do |f|
+      if defined? Rails
+        file = File.join(Rails.root, "/api_docs/#{file_name}.txt")
+      else # slight hackery based on a custom setting defined in the RSpec config
+        file = File.join(config.current_dir, "/api_docs/#{file_name}.txt")
+      end
+
+      File.open(file, 'a') do |f|
         # Resource & Action
         f.write "# #{action}\n\n"
 


### PR DESCRIPTION
I have added a simple condition for non-rails projects which allows a property to be set on the RSpec config.

The setting gives rspec_api_blueprint the project's root directory (under the assumption that the spec_helper.rb, or indeed the RSpec config block is located one folder down from the project's root).

tl;dr
Add to your RSpec config block:

```
config.add_setting :current_dir, :default => File.dirname(__FILE__)+'/..'
```
