### PR TITLE
Update before/after block for RSpec 3.x support

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -3,7 +3,7 @@ require "rspec_api_blueprint/string_extensions"
 
 
 RSpec.configure do |config|
-  config.include Rack::Test::Methods, type: :request
+  # config.include Rack::Test::Methods, type: :request
   
   config.before(:suite) do |example|
     if defined? Rails

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -3,7 +3,6 @@ require "rspec_api_blueprint/string_extensions"
 
 
 RSpec.configure do |config|
-  # config.include Rack::Test::Methods, type: :request
   
   config.before(:suite) do |example|
     if defined? Rails

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -3,7 +3,9 @@ require "rspec_api_blueprint/string_extensions"
 
 
 RSpec.configure do |config|
-  config.before(:suite) do
+  config.include Rack::Test::Methods, type: :request
+  
+  config.before(:suite) do |example|
     if defined? Rails
       api_docs_folder_path = File.join(Rails.root, '/api_docs/')
     else
@@ -17,7 +19,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after(:each, type: :request) do
+  config.after(:each, type: :request) do |example|
     response ||= last_response
     request ||= last_request
 

--- a/lib/rspec_api_blueprint/version.rb
+++ b/lib/rspec_api_blueprint/version.rb
@@ -1,3 +1,3 @@
 module RspecApiBlueprint
-  VERSION = "0.0.8"
+  VERSION = "0.1.0"
 end

--- a/rspec_api_blueprint.gemspec
+++ b/rspec_api_blueprint.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency 'rspec-rails'
+  spec.add_dependency 'rspec-rails', '~> 3.0'
 end


### PR DESCRIPTION
Variable `example` is now passed into hooks in RSpec 3.x; Also include `Rack::Test::Methods` which fixes #12
