### PR TITLE
Add missing example parameter in block && fix spec path

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after(:each, type: :request) do
+  config.after(:each, type: :request) do |example|
     response ||= last_response
     request ||= last_request
 
@@ -32,7 +32,8 @@ RSpec.configure do |config|
 
       action = example_groups[-2][:description_args].first if example_groups[-2]
       example_groups[-1][:description_args].first.match(/(\w+)\sRequests/)
-      file_name = $1.underscore
+      path = example.metadata[:example_group][:file_path]
+      file_name = File.basename(path).underscore
 
       if defined? Rails
         file = File.join(Rails.root, "/api_docs/#{file_name}.txt")


### PR DESCRIPTION
Fix:
- `Failure/Error: Unable to find matching line from backtrace 'example' is not available from within an example (e.g. an 'it' block) or from constructs that run in the scope of an example (e.g. 'before', 'let', etc). It is only available on an example group (e.g. a 'describe' or 'context' block).`. So I added `example` in the `request` block
- `undefined method underscore' for nil:NilClass` in `file_name = $1.underscore`, so I retrieved the path from `example.metadata[:example_group][:file_path]`

Resolves https://github.com/calderalabs/rspec_api_blueprint/issues/15