### PR TITLE
Add support for RSpec 3+

### DIFF
--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -17,10 +17,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after(:each, type: :request) do
-    response ||= last_response
-    request ||= last_request
-
+  config.after(:each, type: :request) do |example|
     if response
       example_group = example.metadata[:example_group]
       example_groups = []


### PR DESCRIPTION
RSpec 3+ uses the variables `request` and `response` instead of `last_request` and `last_response`. This PR updates the gem to use these variables. 