### PR TITLE
Sinatra Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Write tests using the following convention:
 - Tests must be placed in `spec/requests` folder or they have to be tagged with `type: :request`
 - Top level descriptions are named after the model (plural form) followed by the word “Requests”. For a example model called Arena it would be “Arenas Requests”.
 - Second level descriptions are actions in the form of “VERB path”. For the show action of the Arenas controller it would be “GET /arenas/{id}”.
+- Run your specs as normal and files named after the plural form of the model will
+ be created in a folder at the root directory of your project named
+'/api_docs'. The documentation for Arenas would be at
+`<project_root>/api_docs/arenas.txt`
 
 Example:
 

--- a/lib/rspec_api_blueprint.rb
+++ b/lib/rspec_api_blueprint.rb
@@ -1,6 +1,8 @@
 require "rspec_api_blueprint/version"
 require "rspec_api_blueprint/string_extensions"
 
+require "active_support/all"
+
 
 RSpec.configure do |config|
   config.before(:suite) do
@@ -17,7 +19,7 @@ RSpec.configure do |config|
     end
   end
 
-  config.after(:each, type: :request) do
+  config.after(:each, type: :request) do |example|
     response ||= last_response
     request ||= last_request
 
@@ -27,7 +29,7 @@ RSpec.configure do |config|
 
       while example_group
         example_groups << example_group
-        example_group = example_group[:example_group]
+        example_group = example_group[:parent_example_group]
       end
 
       action = example_groups[-2][:description_args].first if example_groups[-2]
@@ -46,6 +48,9 @@ RSpec.configure do |config|
 
         # Request
         request_body = request.body.read
+        if !request_body.present?
+          request_body = request.params.to_json
+        end
         authorization_header = request.env ? request.env['Authorization'] : request.headers['Authorization']
 
         if request_body.present? || authorization_header.present?

--- a/rspec_api_blueprint.gemspec
+++ b/rspec_api_blueprint.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
 
   spec.add_dependency 'rspec-rails'
+  spec.add_dependency 'activesupport'
 end


### PR DESCRIPTION
solves deprication warning for:

The `:example_group` key in an example group's metadata hash is deprecated. Use the example group's hash directly for the computed keys and `:parent_example_group` to access the parent example group metadata instead. Called from /home/chris/dev/forked_gems/rspec_api

Also solves scope issue with rspec hooks, the example needs tobe passed
into the block.

if running within another example raises error. for example:
  config.around(:each) do |example|
    DB.transaction(:rollback=>:always, :auto_savepoint=>true) { example.run }
  end
when a example is called it rases an error.

Adds support for non-Rails(Sintra) apps tested via rspec and Rack::test
read from params if body is empty
Sinatra handels POST and PATCH differently from the other requests for
json.

Signed-off-by: ChrisCPO <ChrisCPO@gmail.com>